### PR TITLE
  HOTFIX: Add missing run() call in main execution path

### DIFF
--- a/vibecoder.py
+++ b/vibecoder.py
@@ -311,6 +311,11 @@ if __name__ == "__main__":
         else:
             # Default to using the session name as workdir
             workdir = session
+        
+        # Call run with all parameters
+        run(session=session, workdir=workdir,
+            autoapprove=args.autoapprove, autocontinue=args.autocontinue,
+            check_finished=args.check_finished)
 
 
 


### PR DESCRIPTION
 Summary
  Fixes critical bug where the default command execution path was missing the `run()` function call, causing the script to parse arguments correctly but exit without executing any functionality.